### PR TITLE
Added Tox wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 build/
 dist/
 ProxyTypes.egg-info/
+*.out
+*.geany
+.tox/

--- a/README.txt
+++ b/README.txt
@@ -280,6 +280,28 @@ you don't want to use any of the standard three ways of defining
 to subclass ``AbstractProxy`` or ``AbstractWrapper`` and provide your own
 way of defining ``__subject__``.
 
+Tests
+-----
+
+To run unittests across multiple Python versions, first install the necessary Python versions:
+
+    sudo add-apt-repository ppa:deadsnakes/ppa
+    sudo apt-get update
+    sudo apt-get install python-dev python3.4-minimal python3.4-dev python3.5-minimal python3.5-dev python3.6 python3.6-dev
+
+Then to run all [tests](http://tox.readthedocs.org/en/latest/):
+
+    tox
+
+To run tests for a specific environment (e.g. Python 2.7):
+    
+    tox -e py27
+
+To run a specific test:
+    
+    export TESTNAME=.additional_tests; tox -e py34
+    
+    export TESTNAME=.TestObjectProxy.testNumbers; tox -e py36
 
 Mailing List
 ------------

--- a/test_proxies.py
+++ b/test_proxies.py
@@ -73,13 +73,6 @@ class ProxyTestMixin:
 
         self.checkBasics(v)
 
-
-
-
-
-
-
-
     def checkList(self, v):
         p = self.proxied(v)
         for i in range(len(v)):
@@ -167,7 +160,3 @@ def additional_tests():
     return doctest.DocFileSuite(
         'README.txt', 'quirky-tests.txt', optionflags=doctest.ELLIPSIS,
     )
-
-
-
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py{27,34,35,36}
+recreate = True
+
+[testenv]
+basepython =
+    py27: python2.7
+    py34: python3.4
+    py35: python3.5
+    py36: python3.6
+commands = python setup.py test -s test_proxies{env:TESTNAME:}


### PR DESCRIPTION
Thanks for adding Python 3 support. This change makes it easy to run unittests for all Python versions with a single command.